### PR TITLE
Fix pm2 logging folder and service-worker missing in ecosystem

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -1,14 +1,12 @@
 module.exports = {
-  apps : [{
-    name: "OctoFarm",
-    script: 'app.js',
-    listen_timeout: 10000,
-    watch: '.'
-  }, {
-    script: './service-worker/',
-    watch: ['./service-worker']
-  }],
-
+  apps : [
+	  {
+	    name: "OctoFarm",
+	    script: 'app.js',
+	    listen_timeout: 10000,
+	    watch: '.'
+	  }
+  ],
   deploy : {
     production : {
       user : 'SSH_USERNAME',

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "prestart": "npm install --production",
-    "start": "pm2 flush && pm2 start app.js --name OctoFarm -e 'logs/pm2.error.log' --time",
+    "start": "pm2 flush && pm2 start app.js --name OctoFarm -e ./logs/pm2.error.log -o ./logs/pm2.out.log --time",
     "stop": "pm2 stop OctoFarm",
     "dev": "nodemon ./app.js",
     "test": "jest"


### PR DESCRIPTION
Fixes:
- [x] remove logs folder + file quotes for pm2 (npm start)
- [x] tested on win10
- [x] small cleanup ecosystem.config.js `./service-worker` specification 
- [ ] regression tested on docker containers
