### PR TITLE
441 update nodejs dockers

### DIFF
--- a/alpine.Dockerfile
+++ b/alpine.Dockerfile
@@ -1,4 +1,6 @@
-FROM alpine:3.12 as base
+# https://pkgs.alpinelinux.org/packages?name=nodejs&branch=v3.13
+# Results in NodeJS 14.16.1-r1
+FROM alpine:3.13 as base
 
 RUN apk add --no-cache --virtual .base-deps \
     nodejs \

--- a/monolithic.Dockerfile
+++ b/monolithic.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:13.0.1-stretch
+FROM node:14.16-stretch
 
 # Update Local Repository Index
 RUN apt-get update


### PR DESCRIPTION
- Update alpine NodeJS by looking at the apk package explorer realising that the NodeJS version 14 is bound to the alpine version 3.13
- Updated monolithic to 14.16-stretch

Probably involves building locally and testing the normal stuff. We've been running NodeJS 13/14 for a while now without problems