### PR TITLE
bring back old issue report with updated note about new log dump

### DIFF
--- a/.github/ISSUE_TEMPLATE/developer-task.md
+++ b/.github/ISSUE_TEMPLATE/developer-task.md
@@ -1,0 +1,8 @@
+---
+name: a task created by developers
+about: problem
+---
+
+- Description
+
+- Repro

--- a/.github/ISSUE_TEMPLATE/issue-report.md
+++ b/.github/ISSUE_TEMPLATE/issue-report.md
@@ -5,39 +5,31 @@ title: ""
 labels: bug
 ---
 
-**OctoFarm and system**
-- NodeJS Version [e.g. 13]:
-- OctoFarm Version [e.g. 1.5.5.7]:
-- OctoPrint Version [e.g. 1.4.1]:
-- Docker or pm2:
-- OS:
-- OctoPrint Plugins [e.g. bed visualiser, octoklipper, printtimegenius]: 
+### Versions
 
-**Where is the OctoFarm problem?**
-> Server, NodeJS, MongoDb database or  Website
--
-  
-**Reproduction**
-> To get the problem I had to:
--
+* Your **OctoFarm version** (latest 1.1.13):
+* Your **OctoPrint version** (latest 1.5.3):
+* Docker or pm2:
+* **NodeJS version** 14 or 15 (not for docker):
+* Operating System (f.e. Raspberry Pi OS, Ubuntu, Windows):
+* OctoPrint Plugins (e.g. bed visualiser, octoklipper, printtimegenius): 
 
-**Description**
-To better help the developer understand your issue, please fill in the information below. **Accurately.**
-> The problem:
--    
-> (Optional) To avoid the problem I had to:
-- 
+### Reproduction
 
-**Expected behavior**
-> A clear and concise description of what you expected to happen.
-- 
+* **Location** of the problem (choose Server, NodeJS, MongoDb database or local website)
+* Description of the problem:
+* Steps needed to **reproduce** the problem.
+* Expected behavior:
+* (Optional) To avoid the problem I had to:
 
-**OctoFarm Logs**
+### OctoFarm Logs
+
 If you've got access to the System screen it's better to just upload the log dump file as it will
-contain all relevant information for the developers. If this is checked you can skip the **Versions** section below.
+contain all relevant information for the developers.
 
-1) **OctoFarm Server logs** Add the system page logs .zip file (or just your `./logs` folder content)
+1) **OctoFarm Server logs** Add the system page logs .zip file (if you cant access it, upload your `./logs` folder content here)
 2) **Console logs** in your browser.
    (How to: https://javascript.info/devtools)
 3) **Screenshots**
-   If applicable, add screenshots to help explain your problem.
+   These are always effective, add screenshots to help explain your problem.
+

--- a/.github/ISSUE_TEMPLATE/issue-report.md
+++ b/.github/ISSUE_TEMPLATE/issue-report.md
@@ -1,0 +1,41 @@
+---
+name: Issue Report
+about: Please fill this in to better help the dev help you.
+title: ""
+labels: bug
+
+---
+### To better help the developer understand your issue, please fill in the information below. Failing to do so will waste the developer and your own time in sorting the issue. Thanks!
+
+**Client or Server side error**
+Which part of the serve does this effect? If you don't know/client side then please add screenshots with the browser console "F12" open.
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+4. See error
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Screenshots**
+If applicable, add screenshots to help explain your problem.
+
+**OctoFarm Log Dump**
+ - [ ] Uploaded
+    - If you've got access to the System screen it's better to just upload the log dump file as it will
+      contain all relevant information for the developers. If this is checked you can skip the **Versions** section below.
+
+**Versions (please complete the following information):**
+- NodeJS Version [e.g. 13]
+- OctoFarm Version [e.g. 1.5.5.7]
+- OctoPrint Version [e.g. 1.4.1]
+- OctoPrint Plugins [e.g. bed visualiser, octoklipper, printtimegenius]
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/issue-report.md
+++ b/.github/ISSUE_TEMPLATE/issue-report.md
@@ -1,41 +1,43 @@
 ---
-name: Issue Report
+name: reporting bug or improvement
 about: Please fill this in to better help the dev help you.
 title: ""
 labels: bug
-
 ---
-### To better help the developer understand your issue, please fill in the information below. Failing to do so will waste the developer and your own time in sorting the issue. Thanks!
 
-**Client or Server side error**
-Which part of the serve does this effect? If you don't know/client side then please add screenshots with the browser console "F12" open.
+**OctoFarm and system**
+- NodeJS Version [e.g. 13]:
+- OctoFarm Version [e.g. 1.5.5.7]:
+- OctoPrint Version [e.g. 1.4.1]:
+- Docker or pm2:
+- OS:
+- OctoPrint Plugins [e.g. bed visualiser, octoklipper, printtimegenius]: 
 
-**Describe the bug**
-A clear and concise description of what the bug is.
+**Where is the OctoFarm problem?**
+> Server, NodeJS, MongoDb database or  Website
+-
+  
+**Reproduction**
+> To get the problem I had to:
+-
 
-**To Reproduce**
-Steps to reproduce the behavior:
-1. Go to '...'
-2. Click on '....'
-3. Scroll down to '....'
-4. See error
+**Description**
+To better help the developer understand your issue, please fill in the information below. **Accurately.**
+> The problem:
+-    
+> (Optional) To avoid the problem I had to:
+- 
 
 **Expected behavior**
-A clear and concise description of what you expected to happen.
+> A clear and concise description of what you expected to happen.
+- 
 
-**Screenshots**
-If applicable, add screenshots to help explain your problem.
+**OctoFarm Logs**
+If you've got access to the System screen it's better to just upload the log dump file as it will
+contain all relevant information for the developers. If this is checked you can skip the **Versions** section below.
 
-**OctoFarm Log Dump**
- - [ ] Uploaded
-    - If you've got access to the System screen it's better to just upload the log dump file as it will
-      contain all relevant information for the developers. If this is checked you can skip the **Versions** section below.
-
-**Versions (please complete the following information):**
-- NodeJS Version [e.g. 13]
-- OctoFarm Version [e.g. 1.5.5.7]
-- OctoPrint Version [e.g. 1.4.1]
-- OctoPrint Plugins [e.g. bed visualiser, octoklipper, printtimegenius]
-
-**Additional context**
-Add any other context about the problem here.
+1) **OctoFarm Server logs** Add the system page logs .zip file (or just your `./logs` folder content)
+2) **Console logs** in your browser.
+   (How to: https://javascript.info/devtools)
+3) **Screenshots**
+   If applicable, add screenshots to help explain your problem.


### PR DESCRIPTION
Ok so apparently github haven't released the yml issues to the wild yet :( I've applied for the repo to be included in the beta for them but this is just to bring the old file back in play until that happens.  