### PR TITLE
Remove prerelease filter as it would not work like this

### DIFF
--- a/docs/ENVIRONMENT_SETUP.md
+++ b/docs/ENVIRONMENT_SETUP.md
@@ -1,27 +1,28 @@
 # OctoFarm Server Environment Variables
-OctoFarm Server can be configured with environment variables. In each setup there are ways to do this:
-- specify a `.env` file. This works for all setups:
-    - node, nodemon and pm2
-    - docker-compose: using the `environment` section [(Read docker-compose environment)](https://docs.docker.com/compose/environment-variables/)
-        - docker: using the `--env-file ./.env` command [(Read docker options)](https://docs.docker.com/engine/reference/commandline/run/#options)
+OctoFarm Server can be configured with environment variables. There's different ways to do this **for each setup**:
+- specify a `.env` file. This works for these setups:
+    - NodeJS with `pm2` 
+    - NodeJS with `nodemon`
     - (FUTURE) windows setup (not available yet)
     - (FUTURE) Unix setup (not available yet)
-- specify each variable separately, this can become tedious:
+- docker - specify each variable separately, this can become tedious:
     - docker: using the `-e VARIABLE=value` command repeatedly
+- docker - all at once
+    - docker: using the `--env-file ./.env` command [(Read docker options)](https://docs.docker.com/engine/reference/commandline/run/#options)    
+    - docker-compose: using the `environment` section [(Read docker-compose environment)](https://docs.docker.com/compose/environment-variables/)
+    
 
 ## Required and optional variables
 The following variables are read and used by OctoFarm at startup. Always restart your server after a change.
 
-- MONGO (Required) **the connection to mongodb**
+- MONGO (Required) **the connection to mongodb**. For example:
 > MONGO=mongodb://127.0.0.1:27017/octofarm
-- OCTOFARM_PORT (Optional, default=4000) **the port of the local OctoFarm website**
+- OCTOFARM_PORT (Optional, default=4000) **the port of the local OctoFarm website**. For example:
 > 
 > OCTOFARM_PORT=4000
-- OCTOFARM_ALLOW_PRERELEASE_INSTALL **you want to have the latest premature releases as well, accepting unstable code.**
-> OCTOFARM_PORT=true_or_anything_which_is_not_empty
 
-## (Optional) .env file
-A very simple text file with a variable per line. The following `.env`is already enough to make sure OctoFarm works as you like:
+## The `.env` file
+A very simple text file with a variable per line. The following `.env` is often already enough to make sure OctoFarm works as you like:
 ```
 MONGO=mongodb://127.0.0.1:27017/octofarm
 OCTOFARM_PORT=4000
@@ -44,8 +45,21 @@ Be aware of the following notes:
 Entirely up to you!
 
 Here is how the environment section in docker would look.
-
-to specify variables or use a `.env` file. Note that this .env file will not work like before, you still have to apply those variables.
+```
+services:
+  octofarm:
+    # ... other sections here
+    
+    # environment using colon syntax
+    environment:
+      - MONGO: mongodb://127.0.0.1:27017/octofarm
+      - OCTOFARM_PORT: 4000
+    
+    # ... alternative (watch for whitespace!!) 
+    environment:
+      MONGO=mongodb://127.0.0.1:27017/octofarm
+      OCTOFARM_PORT=4000
+```
 ### Docker 
 Please add each environment variable in a file named `.env` in the folder where you run you docker command.
 If you don't like a file, `-e VARIABLE_NAME=value` is a possible fix, although it is quite hard to maintain it like that.

--- a/server_src/app.constants.js
+++ b/server_src/app.constants.js
@@ -1,7 +1,6 @@
 const MONGO_KEY = "MONGO";
 const OCTOFARM_PORT_KEY = "OCTOFARM_PORT";
 const NON_NPM_MODE_KEY = "NON_NPM_MODE";
-const OCTOFARM_ALLOW_PRERELEASE_INSTALL_KEY = "OCTOFARM_ALLOW_PRERELEASE_INSTALL";
 const defaultMongoStringUnauthenticated = "mongodb://127.0.0.1:27017/octofarm";
 const defaultOctoFarmPort = 4000;
 
@@ -12,10 +11,6 @@ class AppConstants {
 
   static get defaultOctoFarmPort() {
     return defaultOctoFarmPort;
-  }
-
-  static get OCTOFARM_ALLOW_PRERELEASE_INSTALL_KEY() {
-    return OCTOFARM_ALLOW_PRERELEASE_INSTALL_KEY;
   }
 
   static get MONGO_KEY() {

--- a/server_src/routes/index.js
+++ b/server_src/routes/index.js
@@ -447,7 +447,7 @@ router.get(
 );
 
 softwareUpdateChecker
-  .syncLatestOctoFarmRelease(false || process.env[AppConstants.OCTOFARM_ALLOW_PRERELEASE_INSTALL_KEY])
+  .syncLatestOctoFarmRelease(false)
   .then(() => {
     softwareUpdateChecker.checkReleaseAndLogUpdate();
   });


### PR DESCRIPTION
- [x] Remove prerelease env variable
- [x] Improve and update env markdown docs

To clarify the thoughts behind our workflow
- [x] We acknowledge that users who use git pull will always get the latest and not necessarily stable code.
- [x] We agreed to not push rc/prerelease tags to master again, but to dev (or canary)
- [x] We agreed to push release tags to master, and add the release notes as a commit message (or adjust in the automated release)
- [x] We agreed to make the automated prerelease a release on master by manual flick of the switch in the release itself
- [x] Users will not auto-update to dev/canary ever, testers will do this explicitly using git.