### PR TITLE
Node12 friendly abort 

### DIFF
--- a/app-env.js
+++ b/app-env.js
@@ -77,7 +77,7 @@ function removeDeprecatedMongoURIConfigFile() {
 }
 
 function fetchMongoDBConnectionString(persistToEnv = false) {
-  if (!process?.env[AppConstants.MONGO_KEY]) {
+  if (!process.env[AppConstants.MONGO_KEY]) {
     logger.warning(
       `~ ${AppConstants.MONGO_KEY} environment variable is not set. Assuming default: ${AppConstants.MONGO_KEY}=${AppConstants.defaultMongoStringUnauthenticated}`
     );

--- a/app.js
+++ b/app.js
@@ -1,3 +1,7 @@
+if (parseInt(process.version.replace("v", "").split(".")[0]) < 14) {
+  throw "Please make sure Node 14 or higher is installed to run the latest OctoFarm.";
+}
+
 const { setupEnvConfig, fetchMongoDBConnectionString, fetchOctoFarmPort } = require("./app-env");
 const Logger = require("./server_src/lib/logger.js");
 const mongoose = require("mongoose");

--- a/app.js
+++ b/app.js
@@ -1,4 +1,10 @@
-if (parseInt(process.version.replace("v", "").split(".")[0]) < 14) {
+let majorVersion = null;
+try {
+  majorVersion = parseInt(process.version?.replace("v", "").split(".")[0]);
+} catch (e) {
+  // We dont abort on parsing failures
+}
+if (!!majorVersion && majorVersion < 14) {
   throw "Please make sure Node 14 or higher is installed to run the latest OctoFarm.";
 }
 
@@ -9,7 +15,7 @@ const {
   setupExpressServer,
   serveDatabaseIssueFallback,
   serveOctoFarmNormally,
-  ensureSystemSettingsInitiated,
+  ensureSystemSettingsInitiated
 } = require("./app-core");
 
 function bootAutoDiscovery() {
@@ -26,7 +32,7 @@ mongoose
     useNewUrlParser: true,
     useUnifiedTopology: true,
     useFindAndModify: false,
-    serverSelectionTimeoutMS: 2500,
+    serverSelectionTimeoutMS: 2500
   })
   .then(() => ensureSystemSettingsInitiated())
   .then(() => serveOctoFarmNormally(octoFarmServer, fetchOctoFarmPort()))

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -14,6 +14,11 @@ then
     exit 1
 fi
 
+if [ -z "$OCTOFARM_PORT" ]
+then
+    echo "OCTOFARM_PORT=$OCTOFARM_PORT is not defined, the default of 4000 will be assumed. You can override this at any point."
+fi
+
 if [ -d "logs" ]
 then
     mkdir -p logs

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -26,4 +26,4 @@ else
     echo "Logs folder already exists..."
 fi
 
-pm2 start app.js --name OctoFarm --no-daemon -o './logs/pm2.log' -e './logs/pm2.error.log' --time
+pm2 start app.js --name OctoFarm --no-daemon -o './logs/pm2.log' -e './logs/pm2.error.log' --time --restart-delay=1000 --exp-backoff-restart-delay=1500

--- a/docker/monolithic-entrypoint.sh
+++ b/docker/monolithic-entrypoint.sh
@@ -12,6 +12,4 @@ else
     echo "Logs folder already exists..."
 fi
 
-cd /app/
-
-pm2 start app.js --name OctoFarm --no-daemon -o './logs/pm2.log' -e './logs/pm2.error.log' --time
+pm2 start app.js --name OctoFarm --no-daemon -o './logs/pm2.log' -e './logs/pm2.error.log' --time  --restart-delay=1000 --exp-backoff-restart-delay=1500

--- a/docker/test.Dockerfile
+++ b/docker/test.Dockerfile
@@ -1,0 +1,8 @@
+# Test the Node12 environment to crash in a friendly manner
+FROM node:12-stretch-slim
+WORKDIR /app
+RUN npm install -g pm2
+COPY .. /app
+COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+RUN chmod +x /usr/local/bin/entrypoint.sh
+ENTRYPOINT ["bash", "/usr/local/bin/entrypoint.sh"]

--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -4,6 +4,8 @@ module.exports = {
       name: "OctoFarm",
       script: "app.js",
       listen_timeout: 10000,
+      exp_backoff_restart_delay: 1500,
+      restart_delay: 1000,
       watch: ".",
     },
   ],

--- a/package.json
+++ b/package.json
@@ -113,7 +113,7 @@
       "views/**/*"
     ]
   },
-  "engineStrict": true,
+  "engine-strict": true,
   "engines": {
     "node": ">= 14.0.0",
     "npm": ">= 6.10.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "app.js",
   "scripts": {
     "prestart": "npm ci --production",
-    "start": "pm2 flush && pm2 start app.js --name OctoFarm -e ./logs/pm2.error.log -o ./logs/pm2.out.log --time",
+    "start": "pm2 flush && pm2 start app.js --name OctoFarm -e ./logs/pm2.error.log -o ./logs/pm2.out.log --time --restart-delay=1000 --exp-backoff-restart-delay=1500",
     "restart": "pm2 restart OctoFarm",
     "pupdate": "pm2 update",
     "stop": "pm2 stop OctoFarm",
@@ -30,7 +30,7 @@
     "pi",
     "node"
   ],
-  "author": "James Mackay (NotExpectedYet) & David Zwa",
+  "author": "James Mackay (NotExpectedYet) & David Zwart (davidzwa)",
   "license": "ISC",
   "dependencies": {
     "archiver": "^5.3.0",

--- a/test-node12.Dockerfile
+++ b/test-node12.Dockerfile
@@ -1,8 +1,12 @@
 # Test the Node12 environment to crash in a friendly manner
 FROM node:12-stretch-slim
 WORKDIR /app
+
 RUN npm install -g pm2
-COPY .. /app
-COPY entrypoint.sh /usr/local/bin/entrypoint.sh
+
+COPY ../ /app
+
+COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 RUN chmod +x /usr/local/bin/entrypoint.sh
+
 ENTRYPOINT ["bash", "/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
- [x] Add restart delay and backoff to `npm start` as well as entrypoint scripts.
- [x] Test with throw in app (quickest failure possible)
- [x] Test with test-node12.Dockerfile
- [x] Test with mono and alpy (windhose)
- [x] ~Fix .npmrc file instead of engine section~ both do not work

If necessary
- [x] Add friendly node12 abort msg at start