### PR TITLE
Fix deprecated OP API call in state + backwards compat util

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,7 @@ All notable changes to this project will be documented in this file.
     - Fixed #576, #577: correct some function calls in PrinterClean
     - Fixed #542, #381: ensureIndex mongoose warning and circular Runner import resolved 
     - Fixed #598: printer settingsAppearance missing will not cause failure anymore
-    - Fixed #596: new API and route for pluginmanager (plugins cached now correct)
+    - Fixed #596: changed OctoPrint plugin manager repository to new route with backwards compatibility version check 
 
 
 ## [v1.1.13-hotfix]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,8 @@ All notable changes to this project will be documented in this file.
     - Fixed #567: heatmap error (race condition) in PrinterClean for any newly created database
     - Fixed #576, #577: correct some function calls in PrinterClean
     - Fixed #542, #381: ensureIndex mongoose warning and circular Runner import resolved 
+    - Fixed #598: printer settingsAppearance missing will not cause failure anymore
+    - Fixed #596: new API and route for pluginmanager (plugins cached now correct)
 
 
 ## [v1.1.13-hotfix]

--- a/package-lock.json
+++ b/package-lock.json
@@ -85,6 +85,7 @@
         "postcss": "^8.2.15",
         "prettier": "^2.3.0",
         "rimraf": "^3.0.2",
+        "semver": "^6.3.0",
         "supertest": "^6.1.3",
         "vinyl-buffer": "^1.0.1",
         "vinyl-source-stream": "^2.0.0"

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "passport-local": "^1.0.0",
     "passport-remember-me": "0.0.1",
     "request": "^2.88.2",
+    "semver": "^6.3.0",
     "simple-git": "^2.38.0",
     "systeminformation": "^5.6.12",
     "wake_on_lan": "^1.0.0",

--- a/server_src/runners/printerTicker.js
+++ b/server_src/runners/printerTicker.js
@@ -25,7 +25,7 @@ class PrinterTicker {
     }
   }
 
-  static async addIssue(date, printer, message, state, printerID) {
+  static addIssue(date, printer, message, state, printerID) {
     let id = null;
     if (currentIssues.length === 0) {
       //first issue
@@ -46,6 +46,7 @@ class PrinterTicker {
       currentIssues.shift();
     }
   }
+
   static async removeIssue(id) {
     const index = _.findIndex(currentIssues, function (o) {
       return o.id == id;

--- a/server_src/runners/state.js
+++ b/server_src/runners/state.js
@@ -2558,7 +2558,7 @@ class Runner {
         await PrinterTicker.addIssue(
           new Date(),
           farmPrinters[index].printerURL,
-          "Grabbed plugin list",
+          `Grabbed plugin list (OctoPrint compatibility: ${farmPrinters[index].octoPrintVersion})`,
           "Complete",
           farmPrinters[index]._id
         );

--- a/server_src/runners/state.js
+++ b/server_src/runners/state.js
@@ -2544,14 +2544,14 @@ class Runner {
     return ClientAPI.getRetry(
       farmPrinters[index].printerURL,
       farmPrinters[index].apikey,
-      "api/plugin/pluginmanager"
+      "plugin/pluginmanager/plugins"
     )
       .then((res) => {
         return res.json();
       })
-      .then((res) => {
-        farmPrinters[index].pluginsList = res.repository.plugins;
-        PrinterTicker.addIssue(
+      .then(async (res) => {
+        farmPrinters[index].pluginsList = res.plugins;
+        await PrinterTicker.addIssue(
           new Date(),
           farmPrinters[index].printerURL,
           "Grabbed plugin list",
@@ -2559,8 +2559,8 @@ class Runner {
           farmPrinters[index]._id
         );
       })
-      .catch((err) => {
-        PrinterTicker.addIssue(
+      .catch(async (err) => {
+        await PrinterTicker.addIssue(
           new Date(),
           farmPrinters[index].printerURL,
           `Error grabbing plugin list information: ${err}`,
@@ -2765,14 +2765,14 @@ class Runner {
         // Update info to DB
         farmPrinters[index].corsCheck = res.api.allowCrossOrigin;
         farmPrinters[index].settingsApi = res.api;
-        if (farmPrinters[index].settingsAppearance === "undefined") {
+        if (!farmPrinters[index].settingsAppearance) {
           farmPrinters[index].settingsAppearance = res.appearance;
         } else if (farmPrinters[index].settingsAppearance.name === "") {
           farmPrinters[index].settingsAppearance.name = res.appearance.name;
         }
         if (res.plugins["pi_support"]) {
           logger.info("Detected Pi Support!");
-          PrinterTicker.addIssue(
+          await PrinterTicker.addIssue(
             new Date(),
             farmPrinters[index].printerURL,
             "Pi Plugin detected... scanning for version information...",
@@ -2791,7 +2791,7 @@ class Runner {
             version: piSupport.octopi_version
           };
           logger.info("I captured: ", farmPrinters[index].octoPi);
-          PrinterTicker.addIssue(
+          await PrinterTicker.addIssue(
             new Date(),
             farmPrinters[index].printerURL,
             "Sucessfully grabbed OctoPi information...",
@@ -2804,7 +2804,7 @@ class Runner {
             _.isEmpty(farmPrinters[index].costSettings) ||
             farmPrinters[index].costSettings.powerConsumption === 0.5
           ) {
-            PrinterTicker.addIssue(
+            await PrinterTicker.addIssue(
               new Date(),
               farmPrinters[index].printerURL,
               "Cost Plugin detected... Updating OctoFarms Cost settings",
@@ -2864,7 +2864,7 @@ class Runner {
             const printer = await Printers.findById(id);
 
             printer.save();
-            PrinterTicker.addIssue(
+            await PrinterTicker.addIssue(
               new Date(),
               farmPrinters[index].printerURL,
               "Successfully saved PSU control settings...",
@@ -2899,7 +2899,7 @@ class Runner {
           }
         }
 
-        PrinterTicker.addIssue(
+        await PrinterTicker.addIssue(
           new Date(),
           farmPrinters[index].printerURL,
           "Grabbed settings information...",
@@ -2913,8 +2913,8 @@ class Runner {
           `Successfully grabbed Settings for...: ${farmPrinters[index].printerURL}`
         );
       })
-      .catch((err) => {
-        PrinterTicker.addIssue(
+      .catch(async (err) => {
+        await PrinterTicker.addIssue(
           new Date(),
           farmPrinters[index].printerURL,
           `Error grabbing settings information: ${err}`,

--- a/server_src/runners/state.js
+++ b/server_src/runners/state.js
@@ -2553,9 +2553,9 @@ class Runner {
       .then((res) => {
         return res.json();
       })
-      .then(async (res) => {
+      .then((res) => {
         farmPrinters[index].pluginsList = res.repository.plugins;
-        await PrinterTicker.addIssue(
+        PrinterTicker.addIssue(
           new Date(),
           farmPrinters[index].printerURL,
           `Grabbed plugin list (OctoPrint compatibility: ${farmPrinters[index].octoPrintVersion})`,
@@ -2563,8 +2563,8 @@ class Runner {
           farmPrinters[index]._id
         );
       })
-      .catch(async (err) => {
-        await PrinterTicker.addIssue(
+      .catch((err) => {
+        PrinterTicker.addIssue(
           new Date(),
           farmPrinters[index].printerURL,
           `Error grabbing plugin list information: ${err}`,
@@ -2745,7 +2745,7 @@ class Runner {
     }
   }
 
-  static getSettings(id) {
+  async static getSettings(id) {
     const index = _.findIndex(farmPrinters, function (o) {
       return o._id == id;
     });
@@ -2824,7 +2824,7 @@ class Runner {
             };
             const printer = await Printers.findById(id);
 
-            printer.save();
+            await printer.save();
             PrinterTicker.addIssue(
               new Date(),
               farmPrinters[index].printerURL,
@@ -2867,8 +2867,8 @@ class Runner {
             };
             const printer = await Printers.findById(id);
 
-            printer.save();
-            await PrinterTicker.addIssue(
+            await printer.save();
+            PrinterTicker.addIssue(
               new Date(),
               farmPrinters[index].printerURL,
               "Successfully saved PSU control settings...",
@@ -2899,11 +2899,11 @@ class Runner {
             }
             const printer = await Printers.findById(id);
             printer.camURL = farmPrinters[index].camURL;
-            printer.save();
+            await printer.save();
           }
         }
 
-        await PrinterTicker.addIssue(
+        PrinterTicker.addIssue(
           new Date(),
           farmPrinters[index].printerURL,
           "Grabbed settings information...",
@@ -2917,8 +2917,8 @@ class Runner {
           `Successfully grabbed Settings for...: ${farmPrinters[index].printerURL}`
         );
       })
-      .catch(async (err) => {
-        await PrinterTicker.addIssue(
+      .catch((err) => {
+        PrinterTicker.addIssue(
           new Date(),
           farmPrinters[index].printerURL,
           `Error grabbing settings information: ${err}`,

--- a/server_src/runners/state.js
+++ b/server_src/runners/state.js
@@ -2745,7 +2745,7 @@ class Runner {
     }
   }
 
-  async static getSettings(id) {
+  static async getSettings(id) {
     const index = _.findIndex(farmPrinters, function (o) {
       return o._id == id;
     });

--- a/server_src/utils/compatibility.utils.js
+++ b/server_src/utils/compatibility.utils.js
@@ -1,0 +1,13 @@
+const semver = require("semver");
+
+/**
+ * OctoPrint's plugin manager has an deprecated API for semver >=1.6.0
+ * @param semverString
+ */
+function checkPluginManagerAPIDeprecation(semverString) {
+  return semver.satisfies(semver.coerce(semverString), ">=1.6.0");
+}
+
+module.exports = {
+  checkPluginManagerAPIDeprecation
+};

--- a/test/domain-shared/compatibility-util.test.js
+++ b/test/domain-shared/compatibility-util.test.js
@@ -1,0 +1,11 @@
+const {checkPluginManagerAPIDeprecation} = require("../../server_src/utils/compatibility.utils");
+
+describe("CompatibilityUtil", () => {
+  it("new PluginManager API should be compatible with versions >= 1.6.0", () => {
+      expect(checkPluginManagerAPIDeprecation("1.5.3")).toBe(false);
+      expect(checkPluginManagerAPIDeprecation("1.6.0")).toBe(true);
+      expect(checkPluginManagerAPIDeprecation("2.0.0.dev1385+gb202c6db5.dirty")).toBe(true);
+      expect(checkPluginManagerAPIDeprecation("1.5.3.dev1385+gb202c6db5.dirty")).toBe(false);
+      expect(checkPluginManagerAPIDeprecation("1.6.0.dev1385+gb202c6db5.dirty")).toBe(true);
+  });
+});


### PR DESCRIPTION
- [x] 1.6.0 - deprecated plugin API called
- [x] Wrong data taken from call
- [x] Undefined 'settingsAppearance' undefined check bug
- [x] Missing awaits (although async is unecessary)
- [x] Changelog

Furthermore:
- [x] Revert plugin back to repository.plugins
- [x] Fix compat check printer version
- [x] Test compat util