### PR TITLE
Set node_env with production as default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ All notable changes to this project will be documented in this file.
     - Added Webpack to replace Gulp frontend bundler
     - Rewrote dashboard page and completely refactored javascript code in browser
     - Moved filament cleaner startup to app-core
+    - Made NODE_ENV to be production by default causing the @octofarm/client bundle to be loaded and console logging to be filtered with level INFO/ERROR
 
 ### Removed
     - Gulp packages and gulp as bundler

--- a/client_src/package.json
+++ b/client_src/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@octofarm/client",
-  "version": "0.1.0-rc1-build2506-2036",
+  "version": "0.1.0-rc1-build0107-2125",
   "description": "The website client for OctoFarm bundled using webpack.",
   "scripts": {
     "build": "webpack",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "octofarm",
-  "version": "1.1.14-rc1",
+  "version": "1.2-rc1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "octofarm",
-      "version": "1.1.14-rc1",
+      "version": "1.2-rc1",
       "license": "ISC",
       "dependencies": {
-        "@octofarm/client": "^0.1.0-rc1-build2506-2036",
+        "@octofarm/client": "^0.1.0-rc1-build0107-2125",
         "archiver": "^5.3.0",
         "bcryptjs": "^2.4.3",
         "connect-flash": "^0.1.1",
@@ -1112,9 +1112,9 @@
       }
     },
     "node_modules/@octofarm/client": {
-      "version": "0.1.0-rc1-build2506-2036",
-      "resolved": "https://registry.npmjs.org/@octofarm/client/-/client-0.1.0-rc1-build2506-2036.tgz",
-      "integrity": "sha512-f9cX3QxUhjbQYqXkqJvn/DCP4jDhKgyAcKa4Ew56AsHNIodrhppKsXdIN/ulbD8AnuBG1vf7m7nR0ZP4Tfxn6Q==",
+      "version": "0.1.0-rc1-build0107-2125",
+      "resolved": "https://registry.npmjs.org/@octofarm/client/-/client-0.1.0-rc1-build0107-2125.tgz",
+      "integrity": "sha512-J4fCr2/biUWSG1fcqNLSC4W6hLGFFE3T+/8LBGX6cUAghgVbuu0BoOYTD8exVQKy/a6rEjssudtoknBNaSiLNA==",
       "bin": {
         "octofarm": "index.js"
       },
@@ -13050,9 +13050,9 @@
       }
     },
     "@octofarm/client": {
-      "version": "0.1.0-rc1-build2506-2036",
-      "resolved": "https://registry.npmjs.org/@octofarm/client/-/client-0.1.0-rc1-build2506-2036.tgz",
-      "integrity": "sha512-f9cX3QxUhjbQYqXkqJvn/DCP4jDhKgyAcKa4Ew56AsHNIodrhppKsXdIN/ulbD8AnuBG1vf7m7nR0ZP4Tfxn6Q=="
+      "version": "0.1.0-rc1-build0107-2125",
+      "resolved": "https://registry.npmjs.org/@octofarm/client/-/client-0.1.0-rc1-build0107-2125.tgz",
+      "integrity": "sha512-J4fCr2/biUWSG1fcqNLSC4W6hLGFFE3T+/8LBGX6cUAghgVbuu0BoOYTD8exVQKy/a6rEjssudtoknBNaSiLNA=="
     },
     "@sindresorhus/is": {
       "version": "0.14.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octofarm",
-  "version": "1.1.14-rc1",
+  "version": "1.2-rc1",
   "description": "OctoFarm is a easy to setup and install web interface that unifies your Octoprint instances for easy monitoring of all your printers. OctoFarm allows you to connect to multiple octoprint instances on your network allowing creating a farm management system. You can control, manage, upload files to any of your instances without ever leaving the tab it's open in.",
   "main": "app.js",
   "scripts": {
@@ -34,7 +34,7 @@
   "author": "James Mackay (NotExpectedYet) & David Zwart (davidzwa)",
   "license": "ISC",
   "dependencies": {
-    "@octofarm/client": "^0.1.0-rc1-build2506-2036",
+    "@octofarm/client": "^0.1.0-rc1-build0107-2125",
     "archiver": "^5.3.0",
     "bcryptjs": "^2.4.3",
     "connect-flash": "^0.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "octofarm",
-  "version": "1.2-rc1",
+  "version": "1.2.0-rc1",
   "description": "OctoFarm is a easy to setup and install web interface that unifies your Octoprint instances for easy monitoring of all your printers. OctoFarm allows you to connect to multiple octoprint instances on your network allowing creating a farm management system. You can control, manage, upload files to any of your instances without ever leaving the tab it's open in.",
   "main": "app.js",
   "scripts": {

--- a/server_src/app.constants.js
+++ b/server_src/app.constants.js
@@ -2,12 +2,16 @@ const MONGO_KEY = "MONGO";
 const OCTOFARM_PORT_KEY = "OCTOFARM_PORT";
 const NON_NPM_MODE_KEY = "NON_NPM_MODE";
 const OCTOFARM_SITE_TITLE_KEY = "OCTOFARM_SITE_TITLE";
+const NODE_ENV_KEY = "NODE_ENV";
 
 const VERSION_KEY = "npm_package_version";
 
 const defaultMongoStringUnauthenticated = "mongodb://127.0.0.1:27017/octofarm";
 const defaultOctoFarmPort = 4000;
 const defaultOctoFarmPageTitle = "OctoFarm";
+const defaultProductionEnv = "production";
+const defaultTestEnv = "test";
+const knownEnvNames = ["development", "production", "test"];
 
 class AppConstants {
   static get defaultMongoStringUnauthenticated() {
@@ -22,8 +26,24 @@ class AppConstants {
     return defaultOctoFarmPageTitle;
   }
 
+  static get knownEnvNames() {
+    return knownEnvNames;
+  }
+
+  static get defaultProductionEnv() {
+    return defaultProductionEnv;
+  }
+
+  static get defaultTestEnv() {
+    return defaultTestEnv;
+  }
+
   static get VERSION_KEY() {
     return VERSION_KEY;
+  }
+
+  static get NODE_ENV_KEY() {
+    return NODE_ENV_KEY;
   }
 
   static get MONGO_KEY() {

--- a/server_src/lib/logger.js
+++ b/server_src/lib/logger.js
@@ -1,7 +1,5 @@
 const winston = require("winston");
-
-const isProduction = process.env.NODE_ENV === "production";
-const isTest = process.env.NODE_ENV === "test";
+const { AppConstants } = require("../app.constants");
 
 const dtFormat = new Intl.DateTimeFormat("en-GB", {
   timeStyle: "medium",
@@ -14,11 +12,14 @@ dateFormat = () => {
 };
 
 class LoggerService {
-  constructor(
-    route,
-    enableFileLogs = true,
-    logFilterLevel = isProduction || isTest ? "warn" : "info"
-  ) {
+  constructor(route, enableFileLogs = true, logFilterLevel) {
+    const isProd = process.env.NODE_ENV === AppConstants.defaultProductionEnv;
+    const isTest = process.env.NODE_ENV === AppConstants.defaultTestEnv;
+
+    if (!logFilterLevel) {
+      logFilterLevel = isProd || isTest ? "warn" : "info";
+    }
+
     this.log_data = null;
     this.route = route;
     this.logger = winston.createLogger({
@@ -29,7 +30,7 @@ class LoggerService {
         ...(enableFileLogs
           ? [
               new winston.transports.File({
-                level: isProduction || isTest ? "warn" : "info",
+                level: isTest ? "warn" : "info", // Irrespective of environment
                 filename: `./logs/${route}.log`,
                 maxsize: "5000000",
                 maxFiles: 5


### PR DESCRIPTION
- [x] Ensure NODE_ENV is set to production by defaujlt
- [x] Adjust client_src package to new build, push build to NPM and use in server package.json
- [x] Adjust server package.json version to `1.2.0-rc1`
- [x] Changelog