### PR TITLE
Bugfix/688-670 api fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,18 @@
 
 All notable changes to this project will be documented in this file.
 
+## [v1.2-rc2]
+
+### Added
+
+### Changed
+
+### Removed
+
+### Fixed
+    - Fixed #665: If Global API check fails due to intial time out, never recovered and tried again increasing timeout.
+    - Fixed #670: File manager initial and subsequent scans we're not recursive. 
+
 ## [v1.2-rc1]
 
 ### Added

--- a/server_src/routes/printers.js
+++ b/server_src/routes/printers.js
@@ -73,7 +73,7 @@ router.post("/resyncFile", ensureAuthenticated, async (req, res) => {
   if (typeof file.fullPath !== "undefined") {
     ret = await Runner.reSyncFile(file.i, file.fullPath);
   } else {
-    ret = await Runner.getFiles(file.i, "files?recursive=true");
+    ret = await Runner.getFiles(file.i, true);
   }
   setTimeout(function () {
     res.send(ret);

--- a/server_src/runners/state.js
+++ b/server_src/runners/state.js
@@ -2141,7 +2141,7 @@ class Runner {
     const printer = farmPrinters[index];
 
     return await this.octoPrintService
-      .getFiles(printer, true, true)
+      .getFiles(printer, recursive)
       .then((res) => {
         return res.json();
       })

--- a/server_src/runners/state.js
+++ b/server_src/runners/state.js
@@ -2675,8 +2675,7 @@ class Runner {
           );
 
           let piSupport = await this.octoPrintService.getPluginPiSupport(
-            farmPrinters[index],
-            true
+            farmPrinters[index]
           );
           piSupport = await piSupport.json();
           logger.info("Got from endpoint: ", piSupport);

--- a/server_src/runners/state.js
+++ b/server_src/runners/state.js
@@ -1013,7 +1013,7 @@ class Runner {
 
   static async compareEnteredKeyToGlobalKey(printer) {
     // Compare entered API key to settings API Key...
-    const globalAPIKeyCheck = await this.octoPrintService.getSettings(printer);
+    const globalAPIKeyCheck = await this.octoPrintService.getSettings(printer, true);
     const errorCode = {
       message:
         "Global API Key detected... unable to authenticate websocket connection",
@@ -1142,7 +1142,7 @@ class Runner {
             typeof farmPrinters[i].fileList === "undefined" ||
             typeof farmPrinters[i].storage === "undefined"
           ) {
-            await Runner.getFiles(id, "files?recursive=true");
+            await Runner.getFiles(id, true);
           } else {
             const currentFilament = await Runner.compileSelectedFilament(
               farmPrinters[i].selectedFilament,
@@ -1278,7 +1278,7 @@ class Runner {
             PrinterTicker.addIssue(
               new Date(),
               farmPrinters[i].printerURL,
-              `${e.message}: Connection refused, trying again in: ${systemSettings.timeout.apiRetry}`,
+              `${e.message}: Connection refused, trying again in: ${systemSettings.timeout.apiRetry / 1000} seconds`,
               "Disconnected",
               farmPrinters[i]._id
             );
@@ -1351,7 +1351,7 @@ class Runner {
             PrinterTicker.addIssue(
               new Date(),
               farmPrinters[i].printerURL,
-              `${e.message} retrying in ${timeout.webSocketRetry}`,
+              `${e.message} retrying in ${timeout.apiRetry / 1000} seconds`,
               "Disconnected",
               farmPrinters[i]._id
             );
@@ -2141,7 +2141,7 @@ class Runner {
     const printer = farmPrinters[index];
 
     return await this.octoPrintService
-      .getFiles(printer, recursive)
+      .getFiles(printer, true, true)
       .then((res) => {
         return res.json();
       })
@@ -2675,7 +2675,8 @@ class Runner {
           );
 
           let piSupport = await this.octoPrintService.getPluginPiSupport(
-            farmPrinters[index]
+            farmPrinters[index],
+            true
           );
           piSupport = await piSupport.json();
           logger.info("Got from endpoint: ", piSupport);

--- a/server_src/services/octoprint/__mocks__/octoprint-api.service.js
+++ b/server_src/services/octoprint/__mocks__/octoprint-api.service.js
@@ -23,7 +23,6 @@ class OctoprintApiService {
 
   async getRetry(printerURL, apiKey, item) {
     const message = `Connecting to OctoPrint Mock API: ${item} | ${printerURL}`;
-    logger.info(`${message} | timeout: ${this.timeout.apiTimeout}`);
     return await this.get(printerURL, apiKey, item);
   }
 

--- a/server_src/services/octoprint/octoprint-api-client.service.js
+++ b/server_src/services/octoprint/octoprint-api-client.service.js
@@ -65,7 +65,7 @@ class OctoprintApiClientService extends OctoprintApiService {
    * @param retry
    * @returns {Promise<*|Promise|Promise<unknown> extends PromiseLike<infer U> ? U : (Promise|Promise<unknown>)|*|undefined>}
    */
-  async getFiles(printer, recursive = true, retry = false) {
+  async getFiles(printer, recursive = false, retry = false) {
     return this.getWithOptionalRetry(printer, apiFiles(recursive), retry);
   }
 
@@ -116,7 +116,7 @@ class OctoprintApiClientService extends OctoprintApiService {
     );
   }
 
-  async getUsers(printer, retry = true) {
+  async getUsers(printer, retry = false) {
     return this.getWithOptionalRetry(printer, apiUsers, retry);
   }
 

--- a/server_src/services/octoprint/octoprint-api-client.service.js
+++ b/server_src/services/octoprint/octoprint-api-client.service.js
@@ -38,12 +38,12 @@ class OctoprintApiClientService extends OctoprintApiService {
     }
   }
 
-  async postPrinter(printer, route, data, timeout = false) {
+  async postPrinter(printer, route, data, timeout = true) {
     OctoprintApiClientService.validatePrinter(printer);
     return super.post(printer.printerURL, printer.apikey, route, data, timeout);
   }
 
-  async getWithOptionalRetry(printer, route, retry = false) {
+  async getWithOptionalRetry(printer, route, retry = true) {
     OctoprintApiClientService.validatePrinter(printer);
     if (retry) {
       return await this.getRetry(printer.printerURL, printer.apikey, route);
@@ -54,7 +54,7 @@ class OctoprintApiClientService extends OctoprintApiService {
     }
   }
 
-  async getSettings(printer, retry = false) {
+  async getSettings(printer, retry = true) {
     return this.getWithOptionalRetry(printer, apiSettingsPart, retry);
   }
 
@@ -65,7 +65,7 @@ class OctoprintApiClientService extends OctoprintApiService {
    * @param retry
    * @returns {Promise<*|Promise|Promise<unknown> extends PromiseLike<infer U> ? U : (Promise|Promise<unknown>)|*|undefined>}
    */
-  async getFiles(printer, recursive = false, retry = false) {
+  async getFiles(printer, recursive = true, retry = true) {
     return this.getWithOptionalRetry(printer, apiFiles(recursive), retry);
   }
 
@@ -76,19 +76,19 @@ class OctoprintApiClientService extends OctoprintApiService {
    * @param retry
    * @returns {Promise<*|Promise|Promise<unknown> extends PromiseLike<infer U> ? U : (Promise|Promise<unknown>)|*|undefined>}
    */
-  async getFile(printer, path, retry = false) {
+  async getFile(printer, path, retry = true) {
     return this.getWithOptionalRetry(printer, apiFile(path), retry);
   }
 
-  async getConnection(printer, retry = false) {
+  async getConnection(printer, retry = true) {
     return this.getWithOptionalRetry(printer, apiConnection, retry);
   }
 
-  async getPrinterProfiles(printer, retry = false) {
+  async getPrinterProfiles(printer, retry = true) {
     return this.getWithOptionalRetry(printer, apiPrinterProfiles, retry);
   }
 
-  async getPluginManager(printer, retry = false) {
+  async getPluginManager(printer, retry = true) {
     const printerManagerApiCompatible = checkPluginManagerAPIDeprecation(
       printer.octoPrintVersion
     );
@@ -100,15 +100,15 @@ class OctoprintApiClientService extends OctoprintApiService {
     return this.getWithOptionalRetry(printer, route, retry);
   }
 
-  async getSystemInfo(printer, retry = false) {
+  async getSystemInfo(printer, retry = true) {
     return this.getWithOptionalRetry(printer, apiSystemInfo, retry);
   }
 
-  async getSystemCommands(printer, retry = false) {
+  async getSystemCommands(printer, retry = true) {
     return this.getWithOptionalRetry(printer, apiSystemCommands, retry);
   }
 
-  async getSoftwareUpdateCheck(printer, force, retry = false) {
+  async getSoftwareUpdateCheck(printer, force, retry = true) {
     return this.getWithOptionalRetry(
       printer,
       apiSoftwareUpdateCheck(force),
@@ -116,11 +116,11 @@ class OctoprintApiClientService extends OctoprintApiService {
     );
   }
 
-  async getUsers(printer, retry = false) {
+  async getUsers(printer, retry = true) {
     return this.getWithOptionalRetry(printer, apiUsers, retry);
   }
 
-  async getPluginPiSupport(printer, retry = false) {
+  async getPluginPiSupport(printer, retry = true) {
     return this.getWithOptionalRetry(printer, apiPluginPiSupport, retry);
   }
 

--- a/server_src/services/octoprint/octoprint-api-client.service.js
+++ b/server_src/services/octoprint/octoprint-api-client.service.js
@@ -38,12 +38,12 @@ class OctoprintApiClientService extends OctoprintApiService {
     }
   }
 
-  async postPrinter(printer, route, data, timeout = true) {
+  async postPrinter(printer, route, data, timeout = false) {
     OctoprintApiClientService.validatePrinter(printer);
     return super.post(printer.printerURL, printer.apikey, route, data, timeout);
   }
 
-  async getWithOptionalRetry(printer, route, retry = true) {
+  async getWithOptionalRetry(printer, route, retry = false) {
     OctoprintApiClientService.validatePrinter(printer);
     if (retry) {
       return await this.getRetry(printer.printerURL, printer.apikey, route);
@@ -54,7 +54,7 @@ class OctoprintApiClientService extends OctoprintApiService {
     }
   }
 
-  async getSettings(printer, retry = true) {
+  async getSettings(printer, retry = false) {
     return this.getWithOptionalRetry(printer, apiSettingsPart, retry);
   }
 
@@ -65,7 +65,7 @@ class OctoprintApiClientService extends OctoprintApiService {
    * @param retry
    * @returns {Promise<*|Promise|Promise<unknown> extends PromiseLike<infer U> ? U : (Promise|Promise<unknown>)|*|undefined>}
    */
-  async getFiles(printer, recursive = true, retry = true) {
+  async getFiles(printer, recursive = true, retry = false) {
     return this.getWithOptionalRetry(printer, apiFiles(recursive), retry);
   }
 
@@ -76,19 +76,19 @@ class OctoprintApiClientService extends OctoprintApiService {
    * @param retry
    * @returns {Promise<*|Promise|Promise<unknown> extends PromiseLike<infer U> ? U : (Promise|Promise<unknown>)|*|undefined>}
    */
-  async getFile(printer, path, retry = true) {
+  async getFile(printer, path, retry = false) {
     return this.getWithOptionalRetry(printer, apiFile(path), retry);
   }
 
-  async getConnection(printer, retry = true) {
+  async getConnection(printer, retry = false) {
     return this.getWithOptionalRetry(printer, apiConnection, retry);
   }
 
-  async getPrinterProfiles(printer, retry = true) {
+  async getPrinterProfiles(printer, retry = false) {
     return this.getWithOptionalRetry(printer, apiPrinterProfiles, retry);
   }
 
-  async getPluginManager(printer, retry = true) {
+  async getPluginManager(printer, retry = false) {
     const printerManagerApiCompatible = checkPluginManagerAPIDeprecation(
       printer.octoPrintVersion
     );
@@ -100,15 +100,15 @@ class OctoprintApiClientService extends OctoprintApiService {
     return this.getWithOptionalRetry(printer, route, retry);
   }
 
-  async getSystemInfo(printer, retry = true) {
+  async getSystemInfo(printer, retry = false) {
     return this.getWithOptionalRetry(printer, apiSystemInfo, retry);
   }
 
-  async getSystemCommands(printer, retry = true) {
+  async getSystemCommands(printer, retry = false) {
     return this.getWithOptionalRetry(printer, apiSystemCommands, retry);
   }
 
-  async getSoftwareUpdateCheck(printer, force, retry = true) {
+  async getSoftwareUpdateCheck(printer, force, retry = false) {
     return this.getWithOptionalRetry(
       printer,
       apiSoftwareUpdateCheck(force),
@@ -120,7 +120,7 @@ class OctoprintApiClientService extends OctoprintApiService {
     return this.getWithOptionalRetry(printer, apiUsers, retry);
   }
 
-  async getPluginPiSupport(printer, retry = true) {
+  async getPluginPiSupport(printer, retry = false) {
     return this.getWithOptionalRetry(printer, apiPluginPiSupport, retry);
   }
 

--- a/server_src/services/octoprint/octoprint-api.service.js
+++ b/server_src/services/octoprint/octoprint-api.service.js
@@ -62,11 +62,11 @@ class OctoprintApiService {
       // If timeout exceeds max cut off then give up... Printer is considered offline.
       if (this.timeout.apiTimeout >= this.timeout.apiRetryCutoff) {
         logger.info(`Timeout Exceeded: ${item} | ${printerURL}`);
-        // Reset timeout for next printer...
-        this.timeout.apiTimeout = Number(this.timeout.apiTimeout) - 9000;
         throw err;
       }
-      this.timeout.apiTimeout += 9000;
+      // Make sure to use the settings for api retry.
+      // TODO: Fix apiRetryCutoff + apiRetry as they are swapped.
+      this.timeout.apiTimeout = this.timeout.apiRetryCutoff;
 
       return await this.getRetry(printerURL, apiKey, item);
     }


### PR DESCRIPTION
Defaulted these back to true as they we're before the refactor. 

These can be utilised further in the future once the state.js actually sends the flags. Currently it's not sent at all for files or connection attempts and some of these were fixes for OP clients on Wifi that sometimes didn't respond within 1000ms. 

The files one only sends the recursive false flag on a single file update/scan currently, this also needs to be true. Probably should have noticed this when I was reviewing. XD