### PR TITLE
🐛 bugfix/698 monitoring view worker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ All notable changes to this project will be documented in this file.
     - Added Filament Clean back to start up so filament manager and spools list load.
     - Fixed #605: Tool total would show "null" if no spool selected. 
     - Issue with totals not been counted with/without a spool selected on Printer Control.
+    - Fixed #698: Current Operations would try to load the old browser worker. Replaced with sse client.
 
 ## [v1.2-rc1]
 

--- a/client_src/js/dashboard.runner.js
+++ b/client_src/js/dashboard.runner.js
@@ -11,7 +11,6 @@ import {
   getUsageWeightSeries,
   toFixedWeightGramFormatter
 } from "./dashboard/utils/chart.utils";
-import { DashUpdate } from "./dashboard/dashboard.updater";
 import {
   dashboardSSEventHandler,
   workerURL

--- a/client_src/js/monitoring/monitoring-view.state.js
+++ b/client_src/js/monitoring/monitoring-view.state.js
@@ -1,6 +1,6 @@
 // Store the current active view type like camera, panel, location map or list
 let currentViewType = "none";
-const viewTypes = ["panel", "list", "camera", "map"];
+const viewTypes = ["panel", "list", "camera", "map", "current-ops"];
 
 let printerInfo = null;
 let printerControlList = null;

--- a/views/layout.ejs
+++ b/views/layout.ejs
@@ -74,7 +74,6 @@
                     Current Operations</a>
             </li>
             <% if(page.includes("Camera") || page.includes("List") || page.includes("Panel") || page.includes("Printer Map")){ %>
-
                 <li class="nav-item">
                     <div class="input-group p-0 m-0 pr-1  mx-auto">
                         <div class="input-group-prepend">


### PR DESCRIPTION
Note this is a bugfix for `development`, so `canary` will be rebased afterwards.

- Fix old worker being loaded in curr ops since `sse.client` was introduced
- Changelog fixed entry

Its a required PR to RC2 and to be able to test for obvious regressions on canary.