### PR TITLE
Add global API exception handler, more client dupe .json() fixes

### DIFF
--- a/client_src/js/amialive.service.js
+++ b/client_src/js/amialive.service.js
@@ -98,7 +98,7 @@ const amialiveService = async function () {
           try {
             checkUpdateAndNotify(alive.update);
           } catch (e) {
-            console.warn("Could not succesfully parse OctoFarm update notification");
+            console.warn("Could not successfully parse OctoFarm update notification");
           }
         }
 

--- a/client_src/js/lib/modules/Printers/actionButtons.js
+++ b/client_src/js/lib/modules/Printers/actionButtons.js
@@ -216,7 +216,6 @@ function addEventListeners(printer) {
         id: printer._id
       };
       let post = await OctoFarmClient.post("printers/reScanOcto", data);
-      post = await post.json();
       if (post.msg.status !== "error") {
         UI.createAlert("success", post.msg.msg, 3000, "clicked");
       } else {

--- a/client_src/js/lib/modules/customScripts.js
+++ b/client_src/js/lib/modules/customScripts.js
@@ -10,8 +10,7 @@ function getButton(button) {
 
 export default class CustomGenerator {
   static async generateButtons(printers) {
-    let customScripts = await OctoFarmClient.get("settings/customGcode");
-    customScripts = await customScripts.json();
+    let customScripts = await OctoFarmClient.getCustomGcode();
 
     //Draw Scripts
     let area = document.getElementById("customGcodeCommandsArea");

--- a/client_src/js/lib/modules/printerManager.js
+++ b/client_src/js/lib/modules/printerManager.js
@@ -205,16 +205,11 @@ export default class PrinterManager {
           rotate90 = "rotate(90deg)";
         }
       }
-      let systemSettings = await OctoFarmClient.get("settings/client/get");
 
-      systemSettings = await systemSettings.json();
-
-      let serverSettings = await OctoFarmClient.get("settings/server/get");
-      serverSettings = await serverSettings.json();
-
+      let clientSettings = await OctoFarmClient.getClientSettings();
+      let serverSettings = await OctoFarmClient.getServerSettings();
       filamentManager = serverSettings.filamentManager;
-
-      let controlSettings = systemSettings.controlSettings;
+      let controlSettings = clientSettings.controlSettings;
       //Load tools
       if (typeof controlSettings !== "undefined" && controlSettings.filesTop) {
         document.getElementById("printerControls").innerHTML = `

--- a/client_src/js/lib/octofarm_client.js
+++ b/client_src/js/lib/octofarm_client.js
@@ -23,7 +23,19 @@ export default class OctoFarmClient {
   }
 
   static async getHistoryStatistics() {
-    return this.get("history/stats").then((r) => r.json());
+    return this.get("history/stats");
+  }
+
+  static async getClientSettings() {
+    return this.get("settings/client/get");
+  }
+
+  static async getServerSettings() {
+    return this.get("settings/server/get");
+  }
+
+  static async getCustomGcode() {
+    return this.get("settings/customGcode");
   }
 
   static async get(item) {

--- a/client_src/js/lib/octoprint.js
+++ b/client_src/js/lib/octoprint.js
@@ -2,7 +2,17 @@ import UI from "./functions/ui.js";
 import OctoFarmClient from "./octofarm_client";
 
 export default class OctoPrintClient {
+  static validatePrinter(printer) {
+    if (!printer.apikey) {
+      throw new Error("Api key not provided");
+    }
+    if (!printer.printerURL) {
+      throw new Error("Printer URL not provided");
+    }
+  }
+
   static get(printer, item) {
+    this.validatePrinter(printer);
     const url = `${printer.printerURL}/${item}`;
     return fetch(url, {
       method: "GET",
@@ -16,6 +26,7 @@ export default class OctoPrintClient {
   }
 
   static postNOAPI(printer, item, data) {
+    this.validatePrinter(printer);
     const url = `${printer.printerURL}/${item}`;
     return fetch(url, {
       method: "POST",
@@ -30,6 +41,7 @@ export default class OctoPrintClient {
   }
 
   static post(printer, item, data) {
+    this.validatePrinter(printer);
     const url = `${printer.printerURL}/api/${item}`;
     return fetch(url, {
       method: "POST",
@@ -44,6 +56,7 @@ export default class OctoPrintClient {
   }
 
   static folder(printer, item, data) {
+    this.validatePrinter(printer);
     const url = `${printer.printerURL}/api/files/${item}`;
     return fetch(url, {
       method: "POST",
@@ -57,6 +70,7 @@ export default class OctoPrintClient {
   }
 
   static delete(printer, item) {
+    this.validatePrinter(printer);
     const url = `${printer.printerURL}/api/${item}`;
     return fetch(url, {
       method: "DELETE",
@@ -317,7 +331,7 @@ export default class OctoPrintClient {
   }
 
   static async connect(command, printer) {
-    let opts = null;
+    let opts;
     if (command === "connect") {
       opts = {
         command: "connect",
@@ -331,6 +345,7 @@ export default class OctoPrintClient {
         command: "disconnect"
       };
     }
+
     const post = await OctoPrintClient.post(printer, "connection", opts);
     if (typeof post !== "undefined" && post.status === 204) {
       UI.createAlert(

--- a/client_src/js/printerManager/printer-data.js
+++ b/client_src/js/printerManager/printer-data.js
@@ -233,7 +233,7 @@ export function createOrUpdatePrinterTableRow(printers, printerControlList) {
             const printers = await OctoFarmClient.listPrinters();
             await PrinterManager.init(printer._id, printers, printerControlList);
           } catch (e) {
-            console.error(e);
+            console.error(e.stack);
             UI.createAlert(
               "error",
               `Unable to grab latest printer information: ${e}`,
@@ -249,7 +249,7 @@ export function createOrUpdatePrinterTableRow(printers, printerControlList) {
             const printersInfo = await OctoFarmClient.listPrinters();
             await updatePrinterSettingsModal(printersInfo, printer._id);
           } catch (e) {
-            console.error(e);
+            console.error(e.stack);
             UI.createAlert(
               "error",
               `Unable to grab latest printer information: ${e}`,
@@ -265,7 +265,7 @@ export function createOrUpdatePrinterTableRow(printers, printerControlList) {
             const printersInfo = await OctoFarmClient.listPrinters();
             await updatePrinterSettingsModal(printersInfo, printer._id);
           } catch (e) {
-            console.error(e);
+            console.error(e.stack);
             UI.createAlert(
               "error",
               `Unable to grab latest printer information: ${e}`,
@@ -280,7 +280,7 @@ export function createOrUpdatePrinterTableRow(printers, printerControlList) {
           let connectionLogs = await OctoFarmClient.get("printers/connectionLogs/" + printer._id);
           PrinterLogs.loadLogs(printerInfo, connectionLogs);
         } catch (e) {
-          console.error(e);
+          console.error(e.stack);
           UI.createAlert("error", `Unable to grab latest printer information: ${e}`, 0, "clicked");
         }
       });

--- a/server_src/app-fallbacks.js
+++ b/server_src/app-fallbacks.js
@@ -8,6 +8,8 @@ const path = require("path");
 
 const Logger = require("./handlers/logger.js");
 const logger = new Logger("OctoFarm-Fallback-Server");
+const routePath = "./routes";
+const opts = { cwd: __dirname };
 
 function setupFallbackExpressServer() {
   let app = express();

--- a/server_src/app.constants.js
+++ b/server_src/app.constants.js
@@ -13,9 +13,16 @@ const defaultProductionEnv = "production";
 const defaultTestEnv = "test";
 const knownEnvNames = ["development", "production", "test"];
 
+// Make sure the client is up to date with this
+const jsonStringify = false;
+
 const apiRoute = "/api";
 
 class AppConstants {
+  static get jsonStringify() {
+    return jsonStringify;
+  }
+
   static get apiRoute() {
     return apiRoute;
   }

--- a/server_src/constants/state.constants.js
+++ b/server_src/constants/state.constants.js
@@ -1,0 +1,222 @@
+const getWolPowerSubSettingsDefault = () => {
+  return {
+    enabled: false,
+    ip: "255.255.255.0",
+    packets: "3",
+    port: "9",
+    interval: "100",
+    MAC: ""
+  };
+};
+
+const getPowerSettingsDefault = () => {
+  return {
+    powerOnCommand: "",
+    powerOnURL: "",
+    powerOffCommand: "",
+    powerOffURL: "",
+    powerToggleCommand: "",
+    powerToggleURL: "",
+    powerStatusCommand: "",
+    powerStatusURL: "",
+    wol: getWolPowerSubSettingsDefault()
+  };
+};
+
+const getCostSettingsDefault = () => {
+  return {
+    powerConsumption: 0.5,
+    electricityCosts: 0.15,
+    purchasePrice: 500,
+    estimateLifespan: 43800,
+    maintenanceCosts: 0.25
+  };
+};
+
+const getFilterDefaults = () => [
+  "All Printers",
+  "State: Idle",
+  "State: Active",
+  "State: Complete",
+  "State: Disconnected"
+];
+
+const SYSTEM_CHECKS = {
+  api: "api",
+  files: "files",
+  state: "state",
+  profile: "profile",
+  settings: "settings",
+  system: "system"
+
+  //Special
+  // cleaning: "cleaning"
+};
+
+const getSystemChecksDefault = () => {
+  return {
+    [SYSTEM_CHECKS.api]: {
+      status: "danger",
+      date: null
+    },
+    [SYSTEM_CHECKS.files]: {
+      status: "danger",
+      date: null
+    },
+    [SYSTEM_CHECKS.state]: {
+      status: "danger",
+      date: null
+    },
+    [SYSTEM_CHECKS.profile]: {
+      status: "danger",
+      date: null
+    },
+    [SYSTEM_CHECKS.settings]: {
+      status: "danger",
+      date: null
+    },
+    [SYSTEM_CHECKS.system]: {
+      status: "danger",
+      date: null
+    },
+    // TODO Hmm
+    cleaning: {
+      information: {
+        date: null
+      },
+      job: {
+        date: null
+      },
+      file: {
+        date: null
+      },
+      status: "danger",
+      date: null
+    }
+  };
+};
+
+// State category
+const CATEGORY = {
+  Idle: "Idle",
+  Offline: "Offline",
+  Disconnected: "Disconnected",
+  Complete: "Complete",
+  "Error!": "Error!",
+  Active: "Active"
+};
+
+// https://github.com/OctoPrint/OctoPrint/blob/161e21fe0f6344ec3b9b9b541e9b2c472087ba77/src/octoprint/util/comm.py#L913
+const OP_STATE = {
+  Offline: "Offline",
+  OpeningSerial: "Opening serial connection",
+  DetectingSerial: "Detecting serial connection",
+  Connecting: "Connecting",
+  Operational: "Operational",
+  StartingPrintFromSD: "Starting print from SD", // Starting
+  StartSendingPrintToSD: "Starting to send file to SD", // Starting
+  Starting: "Starting", // Starting
+  TransferringFileToSD: "Transferring file to SD", // Transferring
+  PrintingFromSD: "Printing from SD", // Printing
+  SendingFileToSD: "Sending file to SD", // Printing
+  Printing: "Printing", // Printing,
+  Cancelling: "Cancelling",
+  Pausing: "Pausing",
+  Paused: "Paused",
+  Resuming: "Resuming",
+  Finishing: "Finishing",
+  Error: "Error",
+  OfflineAfterError: "Offline after error",
+  UnknownState: "Unknown State ()" // Unknown State (...) needs proper parsing
+};
+
+// All states of the app. Nice to share between server and client
+const PSTATE = {
+  Offline: "Offline",
+  GlobalAPIKey: "Global API Key Issue",
+  Searching: "Searching...",
+  "Error!": "Error!",
+  "No-API": "No-API",
+  Disconnected: "Disconnected",
+  Starting: "Starting",
+  Operational: "Operational",
+  Paused: "Paused",
+  Printing: "Printing",
+  Pausing: "Pausing",
+  Cancelling: "Cancelling",
+  "Offline after error": "Offline after error",
+  Complete: "Complete",
+  Shutdown: "Shutdown",
+  Online: "Online"
+};
+
+const mapStateToColor = (state) => {
+  if (state === PSTATE.Loading) {
+    return { name: "dark", hex: "#262626", category: CATEGORY.Idle };
+  }
+  if (state === PSTATE.Operational) {
+    return { name: "dark", hex: "#262626", category: CATEGORY.Idle };
+  }
+  if (state === PSTATE.Paused) {
+    return { name: "warning", hex: "#583c0e", category: CATEGORY.Idle };
+  }
+  if (state === PSTATE.Printing) {
+    return { name: "warning", hex: "#583c0e", category: CATEGORY.Active };
+  }
+  if (state === PSTATE.Pausing) {
+    return { name: "warning", hex: "#583c0e", category: CATEGORY.Active };
+  }
+  if (state === PSTATE.Cancelling) {
+    return { name: "warning", hex: "#583c0e", category: CATEGORY.Active };
+  }
+  if (state === PSTATE.Starting) {
+    return { name: "warning", hex: "#583c0e", category: CATEGORY.Active };
+  }
+  if (state === PSTATE.GlobalAPIKey) {
+    return { name: "danger", hex: "#2e0905", category: CATEGORY["Error!"] };
+  }
+  if (state === PSTATE["Error!"]) {
+    return { name: "danger", hex: "#2e0905", category: CATEGORY["Error!"] };
+  }
+  if (state === PSTATE.Offline) {
+    return { name: "danger", hex: "#2e0905", category: CATEGORY.Offline };
+  }
+  if (state === PSTATE["Searching"]) {
+    return { name: "danger", hex: "#2e0905", category: CATEGORY.Offline };
+  }
+  if (state === PSTATE.Disconnected) {
+    return { name: "danger", hex: "#2e0905", category: CATEGORY.Disconnected };
+  }
+  if (state === PSTATE["No-API"]) {
+    return { name: "danger", hex: "#2e0905", category: CATEGORY.Offline };
+  }
+  if (state === PSTATE.Complete) {
+    return { name: "success", hex: "#00330e", category: CATEGORY.Complete };
+  }
+  if (state === PSTATE.Shutdown) {
+    return { name: "danger", hex: "#2e0905", category: CATEGORY.Offline };
+  }
+  if (state === PSTATE.Online) {
+    return { name: "success", hex: "#00330e", category: CATEGORY.Idle };
+  }
+  if (state === PSTATE["Offline after error"]) {
+    return { name: "danger", hex: "#2e0905", category: CATEGORY["Error!"] };
+  }
+
+  // TODO is this a smart idea? No error?
+  console.warn("PSTATE not recognized:", state);
+  return { name: "warning", hex: "#583c0e", category: CATEGORY.Active };
+};
+
+module.exports = {
+  getPowerSettingsDefault,
+  getWolPowerSubSettingsDefault,
+  getSystemChecksDefault,
+  getCostSettingsDefault,
+  getFilterDefaults,
+  mapStateToColor,
+  PSTATE,
+  OP_STATE,
+  CATEGORY,
+  SYSTEM_CHECKS
+};

--- a/server_src/container.tokens.js
+++ b/server_src/container.tokens.js
@@ -1,0 +1,11 @@
+const DITokens = {
+  octofarmUpdateService: "octofarmUpdateService",
+  printersStore: "printersStore",
+  printerService: "printerService",
+  printerGroupService: "printerGroupService",
+  sortingFilteringCache: "sortingFilteringCache",
+  serverSettingsService: "serverSettingsService",
+  settingsStore: "settingsStore"
+};
+
+module.exports = DITokens;

--- a/server_src/exceptions/exception.handler.js
+++ b/server_src/exceptions/exception.handler.js
@@ -1,0 +1,21 @@
+const { NotFoundException } = require("./runtime.exceptions");
+
+// https://dev.to/rajajaganathan/express-scalable-way-to-handle-errors-1kd6
+function exceptionHandler(err, req, res, next) {
+  if (err instanceof NotFoundException) {
+    const code = err.statusCode || 404;
+    return res.status(code).send();
+  }
+  if (!!err) {
+    const code = err.statusCode || 500;
+    return res.status(code).send({
+      error: "OctoFarm server experienced an internal error",
+      stack: err.stack
+    });
+  }
+
+  // Will result in not found on API level
+  next();
+}
+
+module.exports = exceptionHandler;

--- a/server_src/tasks.js
+++ b/server_src/tasks.js
@@ -37,10 +37,125 @@ const GITHUB_UPDATE_CHECK_TASK = async () => {
   });
 };
 
+const WEBSOCKET_HEARTBEAT_TASK = () => {
+  // farmPrinters.forEach(function each(client) {
+  //   if (
+  //     typeof client.ws !== "undefined" &&
+  //     typeof client.ws.isAlive !== "undefined"
+  //   ) {
+  //     if (
+  //       client.ws.instance.readyState !== 0 &&
+  //       client.ws.instance.readyState !== 2 &&
+  //       client.ws.instance.readyState !== 3
+  //     ) {
+  //       PrinterTicker.addIssue(
+  //         new Date(),
+  //         farmPrinters[client.ws.index].printerURL,
+  //         "Sending ping message to websocket...",
+  //         "Active",
+  //         farmPrinters[client.ws.index]._id
+  //       );
+  //       if (client.ws.isAlive === false) return client.ws.instance.terminate();
+  //
+  //       // Retry connecting if failed...
+  //       farmPrinters[client.ws.index].webSocket = "info";
+  //       farmPrinters[client.ws.index].webSocketDescription =
+  //         "Checking if Websocket is still alive";
+  //       client.ws.isAlive = false;
+  //       client.ws.instance.ping(noop);
+  //     }
+  //   }
+  // });
+};
+
+const SSE_TASK = () => {
+  //     const currentOperations = await PrinterClean.returnCurrentOperations();
+  //     let printersInformation = await PrinterClean.listPrintersInformation();
+  //     printersInformation = await filterMe(printersInformation);
+  //     printersInformation = await sortMe(printersInformation);
+  //     const printerControlList = await PrinterClean.returnPrinterControlList();
+  //
+  //     if (!!serverSettings.influxExport?.active) {
+  //       if (influxCounter >= 2000) {
+  //         sendToInflux(printersInformation);
+  //         influxCounter = 0;
+  //       } else {
+  //         influxCounter = influxCounter + 500;
+  //       }
+  //       // eslint-disable-next-line no-use-before-define
+  //     }
+  //     const infoDrop = {
+  //       printersInformation: printersInformation,
+  //       currentOperations: currentOperations,
+  //       printerControlList: printerControlList,
+  //       clientSettings: clientSettings
+  //     };
+  //     clientInformation = await stringify(infoDrop);
+  //     clients.forEach((c, index) => {
+  //       c.res.write("data: " + clientInformation + "\n\n");
+  //     });
+};
+
+const SSE_DASHBOARD = () => {
+  // if (interval === false) {
+  //   interval = setInterval(async function () {
+  //     let clientsSettingsCache = await SettingsClean.returnClientSettings();
+  //     if (!clientsSettingsCache) {
+  //       await SettingsClean.start();
+  //       clientsSettingsCache = await SettingsClean.returnClientSettings();
+  //     }
+  //
+  //     let dashboardSettings = clientsSettingsCache.dashboard;
+  //     if (!dashboardSettings) {
+  //       dashboardSettings = getDefaultDashboardSettings();
+  //     }
+  //
+  //     const currentOperations = await PrinterClean.returnCurrentOperations();
+  //     const dashStatistics = await PrinterClean.returnDashboardStatistics();
+  //     const printerInformation = await PrinterClean.listPrintersInformation();
+  //     const infoDrop = {
+  //       printerInformation,
+  //       currentOperations,
+  //       dashStatistics,
+  //       dashboardSettings
+  //     };
+  //
+  //     clientInformation = await stringify(infoDrop);
+  //     for (clientId in clients) {
+  //       clients[clientId].write("retry:" + 10000 + "\n");
+  //       clients[clientId].write("data: " + clientInformation + "\n\n"); // <- Push a message to a single attached client
+  //     }
+  //   }, 5000);
+  // }
+};
 
 const STATE_TRACK_COUNTERS = async () => {
   await Runner.trackCounters();
 };
+
+// TODO we'll have to pool this with a network, event-loop or CPU budget in mind
+const STATE_SETUP_WEBSOCKETS = async () => {
+  // for (let i = 0; i < farmPrinters.length; i++) {
+  //   // Make sure runners are created ready for each printer to pass between...
+  //   await Runner.setupWebSocket(farmPrinters[i]._id);
+  //   PrinterClean.generate(farmPrinters[i], systemSettings.filamentManager);
+  // }
+  // FilamentClean.start(systemSettings.filamentManager);
+};
+
+const STATE_PRINTER_GENERATE_TASK = async () => {
+  // for (let index = 0; index < farmPrinters.length; index++) {
+  //   if (typeof farmPrinters[index] !== "undefined") {
+  //     PrinterClean.generate(farmPrinters[index], systemSettings.filamentManager);
+  //   }
+  // }
+};
+
+const DATABASE_MIGRATIONS_TASK = async () => {
+  // const migrations = require("./migrations");
+  // console.log(migrations);
+};
+
 /**
  * See an overview of this pattern/structure here https://www.youtube.com/watch?v=dQw4w9WgXcQ
  * @param task

--- a/test/domain/printer-group.test.js
+++ b/test/domain/printer-group.test.js
@@ -1,23 +1,19 @@
 const PrinterGroup = require("../../server_src/models/PrinterGroup");
 
 describe("printer group", function () {
-  it("should be invalid if name is empty", function (done) {
+  it("should be invalid if name is empty", () => {
     const m = new PrinterGroup();
 
-    m.validate(function (err) {
-      expect(err.errors.name).toBeTruthy();
-      done();
-    });
+    const errors = m.validateSync();
+    expect(errors.name).toBeTruthy();
   });
 
-  it("should be valid if printers array is empty", function (done) {
+  it("should be valid if printers array is empty", () => {
     const m = new PrinterGroup({
       name: "TestPrinterGroup"
     });
 
-    m.validate(function (err) {
-      expect(err).toBe(null);
-      done();
-    });
+    const errors = m.validateSync();
+    expect(errors).toBeFalsy();
   });
 });


### PR DESCRIPTION
This PR focuses on adding more client fixes for duplicate `.json()` calls. Its an endless process.
Also added global API exception handler, but didnt use it here yet as it will throw off some tests.

Add canary constants which are used in the big PR