### PR TITLE
Update relative logo URIs to be explicit

### DIFF
--- a/server/templates/addPrinters.ejs
+++ b/server/templates/addPrinters.ejs
@@ -5,7 +5,7 @@
             <p>
                 The all-in-one monitoring and management solution for multiple OctoPrint instances.
             </p>
-            <h1><img width="500px" src="assets/images/logo.png" /></h1>
+            <h1><img width="500px" src="/assets/images/logo.png" /></h1>
             <p>
                 Welcome <% if(typeof name != 'undefined'){ %>
                     <%= name %> <% }%>. To get started we need some printers in your farm!

--- a/server/templates/history.ejs
+++ b/server/templates/history.ejs
@@ -1072,7 +1072,7 @@
         <p>
           Come back here when you've completed some prints.
         </p>
-        <h1><img width="500px" src="assets/images/logo.png" /></h1>
+        <h1><img width="500px" src="/assets/images/logo.png" /></h1>
       </div>
     </div>
   </div>

--- a/server/templates/welcome.ejs
+++ b/server/templates/welcome.ejs
@@ -5,7 +5,7 @@
       <p>
         The all-in-one monitoring solution for multiple OctoPrint instances.
       </p>
-      <h1><img width="50%" src="assets/images/logo.png" /></h1>
+      <h1><img width="50%" src="/assets/images/logo.png" /></h1>
       <% if(registration){%>
       <p>Create an account or login</p>
       <a href="/users/register" class="btn btn-primary btn-block mb-2 bg-colour-1"


### PR DESCRIPTION
The logo image is broken on the panel, list and camera views when no printers have been set up yet.  I updated 3 files to change relative links to logo.png to be explicit URI "/assets/images/logo.png".