### PR TITLE
refactor(server): remaining todo for 1.8.0

### DIFF
--- a/server/app.js
+++ b/server/app.js
@@ -34,4 +34,5 @@ const handleServerMessage = (message) => {
     getServerChildProcess().start(handleServerMessage);
 })();
 
-
+//TODO create messaging system between processes
+//TODO split server up into multiple processes. Statistics/API/Printer Connector/System

--- a/server/constants/path.constants.js
+++ b/server/constants/path.constants.js
@@ -1,0 +1,25 @@
+const { join } = require("path");
+
+const ROOT = "/";
+
+const PATH_CONSTANTS = {
+    IMAGES_FOLDER: join(ROOT, "images"),
+    LOGS_FOLDER: join(ROOT, "logs"),
+    TEMP_FOLDER: join(ROOT, "temp"),
+    SERVER_FOLDER: join(ROOT, "server")
+}
+
+const SUB_PATH_CONSTANTS = {
+    HISTORY_COLLECTION_FOLDER: join(PATH_CONSTANTS.IMAGES_FOLDER, "historyCollection"),
+    BACKUP_FOLDER: join(PATH_CONSTANTS.TEMP_FOLDER, "backup")
+}
+
+const UPDATER_PATHS = {
+    REL_UPDATE_ZIP: "../temp/octofarm-update.zip",
+    REL_TEMP: "../temp",
+    REL_SERVER: "../server",
+    REL_BACKUP_SERVER: "../temp/backup",
+    REL_UPDATED_SERVER: "../temp/server"
+}
+
+module.exports = { ROOT, PATH_CONSTANTS, SUB_PATH_CONSTANTS, UPDATER_PATHS }

--- a/server/modules/InlineUpdater/github-client.service.js
+++ b/server/modules/InlineUpdater/github-client.service.js
@@ -38,7 +38,7 @@ class GithubReleaseChecker{
   }
 
   #checkAndParseWantedReleaseNotes(releases){
-    const filteredReleaseNotes = releases.filter((release) => semver.satisfies(release.tag_name, "< " + this.#current_version.replace("-beta.10", ""), {
+    const filteredReleaseNotes = releases.filter((release) => semver.satisfies(release.tag_name, "> " + this.#current_version, {
           includePrerelease: true
         }));
     const latestRelease = releases.find(

--- a/server/processes/updater.process.js
+++ b/server/processes/updater.process.js
@@ -62,13 +62,13 @@ const unzipFileToTemporaryDirectory = (callback) => {
 }
 
 const backupOldServerDirectory = (callback) => {
-    fs.rename("../server2", "../temp/backup", async () => {
+    fs.rename("../server", "../temp/backup", async () => {
         await callback();
     })
 }
 
 const moveNewFilesToServerDirectory = (callback) => {
-    fs.rename("../temp/server", "../server2", async () => {
+    fs.rename("../temp/server", "../server", async () => {
         await callback();
     })
 }

--- a/server/processes/updater.process.js
+++ b/server/processes/updater.process.js
@@ -5,6 +5,7 @@ const Logger = require("../handlers/logger");
 const fs = require("fs");
 const util = require("util");
 const exec = util.promisify(require("child_process").exec);
+const { UPDATER_PATHS } = require("../constants/path.constants");
 
 const logger = new Logger(LOGGER_ROUTE_KEYS.PROCESS_ONLINE_UPDATER);
 // Stop the OctoFarm process
@@ -21,7 +22,7 @@ const isZipFileTasty = async () => {
 }
 
 const unzipFileToTemporaryDirectory = (callback) => {
-    zip.open("../temp/octofarm.zip", {lazyEntries: true}, function(err, zipfile) {
+    zip.open(UPDATER_PATHS.REL_UPDATE_ZIP, {lazyEntries: true}, function(err, zipfile) {
         if (err) throw err;
         zipfile.readEntry();
         zipfile.on("entry", function(entry) {
@@ -30,13 +31,11 @@ const unzipFileToTemporaryDirectory = (callback) => {
                 // Directory file names end with '/'.
                 // Note that entries for directories themselves are optional.
                 // An entry's fileName implicitly requires its parent directories to exist.
-                console.log("This is a folder", entry.fileName, "Create folder...")
                 zipfile.readEntry();
             } else {
                 // file entry
-                console.log("This is a file", entry.fileName, "Copy into created folder")
                 fs.mkdir(
-                    join("../temp", dirname(entry.fileName)),
+                    join(UPDATER_PATHS.REL_TEMP, dirname(entry.fileName)),
                     { recursive: true },
                     (err) => {
                         if (err) throw err;
@@ -46,7 +45,7 @@ const unzipFileToTemporaryDirectory = (callback) => {
                                 zipfile.readEntry();
                             });
                             const writer = fs.createWriteStream(
-                                join("../temp", entry.fileName)
+                                join(UPDATER_PATHS.REL_TEMP, entry.fileName)
                             );
                             readStream.pipe(writer);
                         });
@@ -62,13 +61,13 @@ const unzipFileToTemporaryDirectory = (callback) => {
 }
 
 const backupOldServerDirectory = (callback) => {
-    fs.rename("../server", "../temp/backup", async () => {
+    fs.rename(UPDATER_PATHS.REL_SERVER, UPDATER_PATHS.REL_BACKUP_SERVER, async () => {
         await callback();
     })
 }
 
 const moveNewFilesToServerDirectory = (callback) => {
-    fs.rename("../temp/server", "../server", async () => {
+    fs.rename(UPDATER_PATHS.REL_UPDATED_SERVER, UPDATER_PATHS.REL_SERVER, async () => {
         await callback();
     })
 }
@@ -76,7 +75,7 @@ const moveNewFilesToServerDirectory = (callback) => {
 const updateNodeJSModules = async () => {
     try {
         await exec("npm ci", {
-            cwd: '../server'
+            cwd: UPDATER_PATHS.REL_SERVER
         }, function(error, stdout, stderr) {
             if(error) throw new Error("Error with exec command npm ci! " + error)
             if(stdout) logger.info(stdout)

--- a/server/tasks.js
+++ b/server/tasks.js
@@ -11,6 +11,7 @@ const {
   updatePluginNoticesStore,
   updatePluginStore,
 } = require('./store/octoprint-plugin-list.store');
+const { createMissingSystemPaths } = require("./utils/system-paths.utils");
 const { getInfluxCleanerCache } = require('./cache/influx-export.cache');
 const { FileClean } = require('./services/file-cleaner.service');
 const { sortCurrentOperations } = require('./services/current-operations.service');
@@ -63,6 +64,7 @@ const INITIALISE_PRINTERS_TASK = async () => {
 
 const SERVER_BOOT_TASK = async () => {
   await onlineChecker.check();
+  createMissingSystemPaths();
   if(onlineChecker.airGapped){
     await Promise.allSettled([
       await SystemRunner.initialiseSystemInformation(),

--- a/server/utils/system-paths.utils.js
+++ b/server/utils/system-paths.utils.js
@@ -1,19 +1,31 @@
 const { join } = require("path");
-const systemRoot = "../";
-const logFolder = "logs";
-const imagesFolder = "images";
-const tempFolder = "temp";
+const { ROOT, PATH_CONSTANTS, SUB_PATH_CONSTANTS, UPDATER_PATHS } = require("../constants/path.constants")
+const { existsSync, mkdirSync } = require("fs");
+
+
+const systemRoot = ROOT;
 
 function getLogsPath() {
-  return join(systemRoot, logFolder);
+  return join(ROOT, PATH_CONSTANTS.LOGS_FOLDER);
 }
 
 function getImagesPath() {
-  return join(systemRoot, imagesFolder);
+  return join(ROOT, PATH_CONSTANTS.IMAGES_FOLDER);
 }
 
 function getTempPath(){
-  return join(systemRoot, tempFolder);
+  return join(ROOT, PATH_CONSTANTS.TEMP_FOLDER);
 }
 
-module.exports = { getLogsPath, systemRoot, getImagesPath, getTempPath };
+const createMissingSystemPaths = () => {
+  const pathList = [getLogsPath(), getImagesPath(), getTempPath(), SUB_PATH_CONSTANTS.BACKUP_FOLDER, SUB_PATH_CONSTANTS.HISTORY_COLLECTION_FOLDER]
+
+  for(const path of pathList){
+    const checkPath = "../" + path;
+    if(!existsSync(checkPath)){
+      mkdirSync(checkPath, {recursive: true})
+    }
+  }
+}
+
+module.exports = { getLogsPath, systemRoot, getImagesPath, getTempPath, createMissingSystemPaths };


### PR DESCRIPTION
- [x] Add in a path manager, makes sure all required paths are created on boot
- [x] Add in are you sure and warning message for updater
- [x] Make sure the release is only checking releases not pre/beta
- [ ] Look into using notices on github issues for in-app admin notices
- [ ] Clean up temp folder after upgrade process is complete
- [ ] Add in check for existing download and use that if exists
- [ ] Look into getting process cpu/memory again
- [ ] Document the new GITHUB_TOKEN env variable
- [ ] Documnet the AIR_GAP variable if not
- [ ] #1258 
- [ ] #1259 
- [ ] #1261 
- [ ] #1293 
- [ ] #1309 
- [ ] #1309 
- [ ] #1317 
- [ ] #1326 
- [ ] #1328 
- [ ] #1332 
- [ ] #1333 
- [ ] #1335 - some work done towards this already
- [ ] #1336 - Just documentation work, how to reset admin password
- [ ] #1338 
- [ ] #1334 
- [ ] #1351
- [ ] #1365 - Main one to tackle, should resolve a lot of bugs up above... 